### PR TITLE
Change application, add link to ergo discord

### DIFF
--- a/content/application.html
+++ b/content/application.html
@@ -84,9 +84,10 @@ keywords = ["Sigmanauts","Ergonauts","Ergo","cryptocurrency"]
    </div>
 
    <div class="col-md-12 form-group">
-     <b>Your Discord username? (required):</b><br> 
-     <input type="text" class="form-control" name="discord" required id="discord" maxlength="300" placeholder=" What is your Discord username? (this is required)"><br>
-                  </div>
+  <b>Your Discord username? (required):</b><br> 
+  <input type="text" class="form-control" name="discord" required id="discord" maxlength="300" placeholder=" What is your Discord username? (this is required)">
+  <small class="text-muted">Please ensure you are also a member of the Ergo Discord server: <a href="https://discord.com/invite/ergo-platform-668903786361651200">Join here</a></small><br>
+</div>
 
    <div class="col-md-12 form-group">
      <b>Your Telegram username?</b><br> 

--- a/content/application.html
+++ b/content/application.html
@@ -83,11 +83,11 @@ keywords = ["Sigmanauts","Ergonauts","Ergo","cryptocurrency"]
      <textarea class="form-control" name="improve" wrap="hard" id="improve" cols="30" rows="2" maxlength="1000" placeholder=" If you could improve one thing about Ergo today, what would it be?"></textarea><br>
    </div>
 
-   <div class="col-md-12 form-group">
-  <b>Your Discord username? (required):</b><br> 
-  <input type="text" class="form-control" name="discord" required id="discord" maxlength="300" placeholder=" What is your Discord username? (this is required)">
-  <small class="text-muted">Please ensure you are also a member of the Ergo Discord server: <a href="https://discord.com/invite/ergo-platform-668903786361651200">Join here</a></small><br>
-</div>
+  <div class="col-md-12 form-group">
+    <b>Your Discord username? (required):</b><br> 
+    <input type="text" class="form-control" name="discord" required id="discord" maxlength="300" placeholder=" What is your Discord username? (this is required)">
+    <small class="text-muted">Please ensure you are also a member of the Ergo Discord server: <a href="https://discord.com/invite/ergo-platform-668903786361651200">Join here</a></small><br>
+  </div>
 
    <div class="col-md-12 form-group">
      <b>Your Telegram username?</b><br> 


### PR DESCRIPTION
I've made a small modification to the application form for joining the Sigmanauts Program. I've added a note below the Discord username field to emphasize that it is required for membership and to remind applicants to also join the Ergo Discord server using the provided link.

Some applicants seem to create a discord account solely to join, but don't realize they need to join ergo server to be added to Sig chat.