### PR TITLE
Change email to sigmanauts@protonmail.com

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,7 @@ theme = "beautifulhugo"
 [Author]
   name = "Sigmanaut"
   website = "https://github.com/cafebedouin/sigmanauts"
-  email = "qx@sigmanauts.com"
+  email = "sigmanauts@protonmail.com"
   github = "https://github.com/sigmanauts"
   twitter = "https://twitter.com/sigmanauts"
   telegram = "https://t.me/Ergo_Chats"

--- a/content/contact.html
+++ b/content/contact.html
@@ -20,7 +20,7 @@ draft = 'false'
 
     <p> 
         For more general inquiries, please feel free to contact <a href="https://t.me/rustinmyeye@rustinmyeye" target="_blank">@rustinmyeye</a> on Telegram, send a DM on <a href="https://twitter.com/sigmanauts" target="_blank">Twitter</a>, or you could send an email to 
-        <a href="mailto:qx@sigmanauts.com">qx@sigmanauts.com</a>.
+        <a href="mailto:sigmanauts@protonmail.com">sigmanauts@protonmail.com</a>.
     </p>
     <br>
 


### PR DESCRIPTION
Change email to sigmanauts@protonmail.com

Updated so that emails are sent to  and accessible to cafe, rustinmyeye, glasgow, cannon, and qx 